### PR TITLE
Scripts for processing sputum rnaseq data

### DIFF
--- a/Processing Sputum RNAseq/README.md
+++ b/Processing Sputum RNAseq/README.md
@@ -1,0 +1,39 @@
+# pa-salmon
+## pa-salmon
+
+Using salmon to processes *P. aeruginosa* RNA-seq data
+
+## Overview
+
+1. Create a conda environment with salmon installed called **salmon2**
+    * conda create salmon2
+    * conda activate salmon2
+    * conda install -c bioconda salmon
+    * (https://anaconda.org/bioconda/salmon)
+
+2. Create transcriptome index
+    These are reference genome specific and can be made in decoy-unaware or
+    decoy-aware modes
+    examples: salmon_ti.script, salmon_ti_decoy.script
+
+3. Load fastq files to directories accessible on discovery
+    * keep all fastq files that correspond to a sample (eg paired) in sub-directories
+    * dartfs storage is accessible by discovery but larger than user home dirs
+    but is usually specific to a lab
+    * global scratch can also be used (files last 30 days)
+    * examples: /dartfs-hpc/rc/lab/H/HoganD or /dartfs-hpc/scratch/
+
+4. Map samples to t-index
+    * Use the salmon quant command for fast mapping
+    parameters used in this project were chosen for *P. aeruginosa*
+    and may be bacteria-specific.
+    * Run samples in parallel via job arrays.
+    * examples: salmon_metals_spu.scipt, salmon_metals_spu_decoy.script
+
+5. Collect salmon output (quant.fs files) into count table
+    * the salmon calls save all outputs to files named quant.fs in different
+    directories
+    * almon also uses cDNA gene identifiers
+    * collect them all as columns
+    in a table with column names as sample names and rownames as gene names
+    * example: spu_collect.script

--- a/Processing Sputum RNAseq/quant_collect.R
+++ b/Processing Sputum RNAseq/quant_collect.R
@@ -1,0 +1,72 @@
+## ---------------------------
+##
+## Script name: quant_collect.R
+##
+## Description: Gathers all quant.fs files into a csv
+##
+## Args: dir containing quant.fs files
+##       genome fasta
+##       output file name 
+##
+## Author: Georgia Doing
+##
+## Date Created: 2020-12-19
+##
+## Email: Georgia.Doing.GR@Dartmouth.edu
+##
+## ---------------------------
+##
+## Notes:
+##
+##
+##  User must have write permissions
+##
+## ---------------------------
+#library(Biostrings)
+
+# to recieve commandline input
+args = commandArgs(trailingOnly=TRUE)
+
+# test if there is at least one argument: if not, return an error
+if (length(args)<3) {
+  stop("Must supply dir, genome and out file", call.=FALSE)
+}
+
+## decend into dir to find all quant.fs files
+sf_files <- list.files(args[1], pattern= '.sf', 
+                       recursive = TRUE, full.names = TRUE)
+#print(sf_files)
+## parse file paths to get experiment accession
+sf_names <- sapply(list.files(args[1], pattern= '.sf', 
+                              recursive = TRUE, full.names = FALSE), function(x)
+                                substring(x, regexpr('/[E,S]RX',x)+1, regexpr('/quant',x)-1))
+# Read in the data from all quant files
+sf_datasets <- lapply(sf_files, function(x) read.csv(x, sep = '\t',
+                                                     stringsAsFactors = FALSE))
+# combine into a dataframes of read numbers and TPM, merging by name
+sf_all_reads <- Reduce(function(df1, df2) merge(df1, df2[,c(1,5)], by = 'Name'), sf_datasets)
+rownames(sf_all_reads) <- sf_all_reads$Name
+sf_all_reads <- sf_all_reads[,-c(2:4)]
+
+sf_all_tpm <- Reduce(function(df1, df2) merge(df1, df2[,c(1,4)], by = 'Name'), sf_datasets)
+rownames(sf_all_tpm) <- sf_all_tpm$Name
+sf_all_tpm <- sf_all_tpm[,-c(2,3,5)]
+
+# name columns as experiment accession
+colnames(sf_all_reads) <- c('Name',sf_names)
+colnames(sf_all_tpm) <- c('Name',sf_names)
+
+# load in genome to convert t-index names to gene names
+#genome_fasta <- readDNAStringSet(args[2])
+anns_df <- read.csv(args[2], stringsAsFactors=F)
+
+# convert t-index names to gene names
+sf_all_reads[,1] <- as.character(sapply(rownames(sf_all_reads), function(x) anns_df$X2[anns_df$X1 == x]))
+#colnames(sf_all_reads) <- c('X', colnames(sf_all_reads[-ncol(sf_all_reads)]))
+
+sf_all_tpm[,1] <- as.character(sapply(rownames(sf_all_tpm), function(x) anns_df$X2[anns_df$X1 == x]))
+#colnames(sf_all_tpm) <- c('X', colnames(sf_all_tpm[-ncol(sf_all_tpm)]))
+
+# write out tables for num reads and TPM
+write.csv(sf_all_reads, paste('num_reads_',args[3],sep=''))
+write.csv(sf_all_tpm, paste('TPM_',args[3],sep=''))

--- a/Processing Sputum RNAseq/salmon.yml
+++ b/Processing Sputum RNAseq/salmon.yml
@@ -1,0 +1,6 @@
+channels:
+   - conda-forge
+   - bioconda
+   - defaults
+dependencies:
+   - salmon=1.6.0

--- a/Processing Sputum RNAseq/salmon2.yml
+++ b/Processing Sputum RNAseq/salmon2.yml
@@ -1,0 +1,24 @@
+name: salmon2
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
+  - boost-cpp=1.74.0=h312852a_4
+  - bzip2=1.0.8=h7f98852_4
+  - icu=68.1=h58526e2_0
+  - jemalloc=5.2.1=h9c3ff4c_6
+  - libgcc-ng=11.2.0=h1d223b6_11
+  - libgomp=11.2.0=h1d223b6_11
+  - libjemalloc=5.2.1=h9c3ff4c_6
+  - libstdcxx-ng=11.2.0=he4da1e4_11
+  - libzlib=1.2.11=h36c2ea0_1013
+  - lz4-c=1.9.3=h9c3ff4c_1
+  - salmon=1.5.2=h84f40af_0
+  - tbb=2020.2=h4bd325d_4
+  - xz=5.2.5=h516909a_1
+  - zlib=1.2.11=h36c2ea0_1013
+  - zstd=1.5.0=ha95c52a_0
+prefix: /dartfs-hpc/rc/home/6/f002bx6/.conda/envs/salmon2

--- a/Processing Sputum RNAseq/salmon_metals_spu.script
+++ b/Processing Sputum RNAseq/salmon_metals_spu.script
@@ -1,0 +1,58 @@
+#!/bin/bash -l
+
+################################################################################
+#Script Name: salmon_metals_spu.script
+#Desription : run salmon on sputum +/- metals RNA-seq with decoy-away t index
+#Args       :
+#Author     : Georgia Doing
+#Date       : 10-09-21
+#Email      : Georgia.Doing.GR@Dartmouth.edu
+################################################################################
+
+
+#SBATCH --partition=standard
+#SBATCH --account NCCC
+#SBATCH --job-name salmon.metspu
+#SBATCH --time=03:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=6
+#SBATCH --mail-user=Georgia.Doing.GR@Dartmouth.edu
+#SBATCH --array=0-1
+
+cd ~/salmon
+# note the switch to conda environment 'salmon2' from 'salmon'
+conda activate salmon2
+# read directory names of folders containing fastq files per sample
+# (this is useful for when samples have more than one fastq eg paired-end)
+samparr=(/dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq/*)
+# for record keeping, I echo things so they end up in the slurm job 'out' file
+echo "sample 1: ${samparr[1]}"
+echo "sample 2: ${samparr[2]}"
+echo "task id: $SLURM_ARRAY_TASK_ID"
+# submit the processing of each sample as a job in a job array
+# (keep track of samples by the name of their directory)
+samp="${samparr[$SLURM_ARRAY_TASK_ID]}"
+echo "samp: $samp"
+# read the fastq files from the folder for the current job/sample dir
+fqtemp=($samp/*)
+echo "fq temp: ${fqtemp[*]}"
+# parse the name of the fastq file to save the output with other extension
+base=`basename ${fqtemp[1]} .fastq.gz`
+echo "base: $base"
+# run the salmon quant command
+# note the t index pao1_cdna_k15 has been previous made
+salmon quant -i ~/pa-seq-compendia/t_indxs/pao1_cdna_k15 \
+    # for P. aeruginosa, only map in 'unpaired' mode, (for others use -l A)
+    -l U \
+    # include all fastq files for this sample as a list
+    -r ${fqtemp[*]} \
+    # this output path is in the hogan lab folder on dartfs
+    -o /dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq/salmon_out/$base.salmon \
+    # the following options are what I chose for P. aeruginosa, may change
+    --useVBOpt \
+    --seqBias \
+    --validateMappings \
+    --posBias \
+    --numBootstraps 30 \
+    # allow 6 threads for zippity-quick speed, havent tried more..
+    -p 6

--- a/Processing Sputum RNAseq/salmon_metals_spu_decoy.script
+++ b/Processing Sputum RNAseq/salmon_metals_spu_decoy.script
@@ -1,0 +1,60 @@
+#!/bin/bash -l
+
+################################################################################
+#Script Name: salmon_metals_spu_decoy.script
+#Desription : run salmon on sputum +/- metals RNA-seq with decoy-away t index
+#Args       :
+#Author     : Georgia Doing
+#Date       : 10-09-21
+#Email      : Georgia.Doing.GR@Dartmouth.edu
+################################################################################
+
+
+#SBATCH --partition=standard
+#SBATCH --account NCCC
+#SBATCH --job-name salmon.metspu
+#SBATCH --time=03:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=6
+#SBATCH --mail-user=Georgia.Doing.GR@Dartmouth.edu
+#SBATCH --array=1
+#SBATCH --mem=128G
+#SBATCH --mail-type=END,FAIL
+
+cd ~/salmon
+# note the switch to conda environment 'salmon2' from 'salmon'
+conda activate salmon2
+# read directory names of folders containing fastq files per sample
+# (this is useful for when samples have more than one fastq eg paired-end)
+samparr=(/dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq/*)
+# for record keeping, I echo things so they end up in the slurm job 'out' file
+echo "sample 1: ${samparr[1]}"
+echo "sample 2: ${samparr[2]}"
+echo "task id: $SLURM_ARRAY_TASK_ID"
+# submit the processing of each sample as a job in a job array
+# (keep track of samples by the name of their directory)
+samp="${samparr[$SLURM_ARRAY_TASK_ID]}"
+echo "samp: $samp"
+# read the fastq files from the folder for the current job/sample dir
+fqtemp=($samp/*)
+echo "fq temp: ${fqtemp[*]}"
+# parse the name of the fastq file to save the output with other extension
+base=`basename ${fqtemp[1]} .fastq.gz`
+echo "base: $base"
+# run the salmon quant command
+# note the t index pao1_index_wdecss has been previous made
+salmon quant -i /dartfs-hpc/scratch/f002bx6/salmon/pao1_index_wdecss \
+    # for P. aeruginosa, only map in 'unpaired' mode, (for others use -l A)
+    -l U \
+    # include all fastq files for this sample as a list
+    -r ${fqtemp[*]} \
+    # this output path is in the hogan lab folder on dartfs
+    -o /dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq/salmon_decoy_out/$base.dec.salmon \
+    # the following options are what I chose for P. aeruginosa, may change
+    --useVBOpt \
+    --seqBias \
+    --validateMappings \
+    --posBias \
+    --numBootstraps 30 \
+    # allow 6 threads for zippity-quick speed, havent tried more..
+    -p 6

--- a/Processing Sputum RNAseq/salmon_ti.script
+++ b/Processing Sputum RNAseq/salmon_ti.script
@@ -1,0 +1,35 @@
+#!/bin/bash -l
+
+################################################################################
+#Script Name: salmon_ti.script
+#Desription : create transcriptome indices from cdna fasta
+#Args       : None
+#Author     : Georgia Doing
+#Date       : 10-09-21
+#Email      : Georgia.Doing.GR@Dartmouth.edu
+################################################################################
+
+#SBATCH --job-name=sal_t_index
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --time=00:15:00
+#SBATCH --mail-user=georgia.doing.gr@dartmouth.edu
+#SBATCH --mailt-type=BEGIN,END,FAIL
+
+
+cd ~/salmon
+
+conda activate salmon
+
+#salmon index -t ../t_indxs/pao1_cdna.fa.gz -i ..//t_indxs/pao1_cdna_k15 -k 15
+#salmon index -t ../t_indxs/pa14_cdna.fa.gz -i ../t_indxs/pa14_cdna_k15 -k 15
+
+wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Pseudomonas_aeruginosa/reference/GCA_000006765.1_ASM676v1/GCA_000006765.1_ASM676v1_cds_from_genomic.fna.gz -O Pa_PAO1_cdna.fna.gz
+
+wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Pseudomonas_aeruginosa/reference/GCA_000006765.1_ASM676v1/GCA_000006765.1_ASM676v1_genomic.fna.gz -O Pa_PAO1_genome.fna.gz
+
+wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Staphylococcus_aureus/reference/GCA_000013425.1_ASM1342v1/GCA_000013425.1_ASM1342v1_genomic.fna.gz -O Sa_NCTC8325_genome.fna.gz
+
+wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/fungi/Candida_albicans/representative/GCA_000182965.3_ASM18296v3/GCA_000182965.3_ASM18296v3_genomic.fna.gz -O Ca_SC5314_genome.fna.gz
+
+wget http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/GRCh38.p13.genome.fa.gz -O Human_GRCh38_genome.fa.gz

--- a/Processing Sputum RNAseq/salmon_ti_decoy.script
+++ b/Processing Sputum RNAseq/salmon_ti_decoy.script
@@ -1,0 +1,67 @@
+#!/bin/bash -l
+
+################################################################################
+#Script Name: salmon_ti_decoy.script
+#Desription : create transcriptome indices from cdna fasta
+#Args       : None
+#Author     : Georgia Doing
+#Date       : 10-09-21
+#Email      : Georgia.Doing.GR@Dartmouth.edu
+################################################################################
+
+#SBATCH --job-name=sal_d_indx
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=12
+#SBATCH --time=03:00:00
+#SBATCH --mail-user=georgia.doing.gr@dartmouth.edu
+#SBATCH --mail-type=BEGIN,END,FAIL
+##SBATCH --partition bigmem
+#SBATCH --mem=128G
+
+cd /dartfs-hpc/scratch/f002bx6/salmon
+
+conda activate salmon2
+
+#salmon index -t ../t_indxs/pao1_cdna.fa.gz -i ..//t_indxs/pao1_cdna_k15 -k 15
+#salmon index -t ../t_indxs/pa14_cdna.fa.gz -i ../t_indxs/pa14_cdna_k15 -k 15
+
+#wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Pseudomonas_aeruginosa/reference/GCA_000006765.1_ASM676v1/GCA_000006765.1_ASM676v1_cds_from_genomic.fna.gz -O Pa_PAO1_cdna.fna.gz
+
+wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Pseudomonas_aeruginosa/reference/GCA_000006765.1_ASM676v1/GCA_000006765.1_ASM676v1_genomic.fna.gz -O Pa_PAO1_genome.fna.gz
+
+#wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Staphylococcus_aureus/reference/GCA_000013425.1_ASM1342v1/GCA_000013425.1_ASM1342v1_rna_from_genomic.fna.gz -O /dartfs-hpc/scratch/f002bx6/salmon/Sa_NCTC8325_rna.fna.gz
+
+#wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/bacteria/Staphylococcus_aureus/reference/GCA_000013425.1_ASM1342v1/GCA_000013425.1_ASM1342v1_genomic.fna.gz -O Sa_NCTC8325_genome.fna.gz
+
+#wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/fungi/Candida_albicans/representative/GCA_000182965.3_ASM18296v3/GCA_000182965.3_ASM18296v3_genomic.fna.gz -O Ca_SC5314_genome.fna.gz
+
+#wget http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/GRCh38.p13.genome.fa.gz -O Human_GRCh38_genome.fa.gz
+
+#wget http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/gencode.v38.transcripts.fa.gz -O Human_GRCh38_transcripts.fa.gz
+
+grep "^>" <(gunzip -c Pa_PAO1_genome.fna.gz) | cut -d " " -f 1 > Pa_decoys.txt
+sed -i.bak -e 's/>//g' Pa_decoys.txt
+
+#grep "^>" <(gunzip -c Sa_NCTC8325_genome.fna.gz) | cut -d " " -f 1 > Sa_decoys.txt
+#sed -i.bak -e 's/>//g' Sa_decoys.txt
+
+#grep "^>" <(gunzip -c Ca_SC5314_genome.fna.gz) | cut -d " " -f 1 > Ca_decoys.txt
+#sed -i.bak -e 's/>//g' Ca_decoys.txt
+
+#grep "^>" <(gunzip -c Human_GRCh38_genome.fa.gz) | cut -d " " -f 1 > Hs_decoys.txt
+#sed -i.bak -e 's/>//g' Hs_decoys.txt
+
+
+#cat Sa_decoys.txt Ca_decoys.txt Hs_decoys.txt > all_decoys.txt
+cat Sa_decoys.txt Ca_decoys.txt Hs_decoys.txt Pa_deocys.txt > all_decoys2.txt
+
+#cat Pa_PAO1_cdna.fna.gz Sa_NCTC8325_genome.fna.gz Ca_SC5314_genome.fna.gz Human_GRCh38_genome.fa.gz > gentrome.fa.gz
+
+cat Human_GRCh38_transcripts.fa.gz Pa_PAO1_cdna.fna.gz Sa_NCTC8325_genome.fna.gz Ca_SC5314_genome.fna.gz Human_GRCh38_genome.fa.gz > gentrome2.fa.gz
+#cat Pa_PAO1_cdna_fna.gz Human_GRCh38_genome.fa.gz > gentrome.fa.gz
+#salmon index -t gentrome.fa.gz -d all_decoys.txt -p 12 -k 15 -i pao1_index_wdecss
+
+#salmon index -t /dartfs-hpc/scratch/f002bx6/salmon/Sa_NCTC8325_rna.fna.gz -k 15 -i /dartfs-hpc/scratch/f002bx6/salmon/sa_index_nd
+#salmon index -t /dartfs-hpc/scratch/f002bx6/salmon/Ca_SC5314_genome.fna.gz -k 15 -i /dartfs-hpc/scratch/f002bx6/salmon/ca_index_nd
+
+salmon index -t gentrome2.fa.gz -d all_decoys2.txt -p 12 -i human_index_wdec

--- a/Processing Sputum RNAseq/spu_collect.script
+++ b/Processing Sputum RNAseq/spu_collect.script
@@ -1,0 +1,30 @@
+#!/bin/bash -l
+
+################################################################################
+#Script Name: sal_out_collect.pbs
+#Desription : collect salmon output into matrices
+#Args       : dir     - directory with subdirectories of salmon output
+#             genome  -file to map cDNA names to gene names
+#             outfile - suffix to append to TPM and total_counts output
+#Author     : Georgia Doing
+#Date       : 12-18-20
+#Email      : Georgia.Doing.GR@Dartmouth.edu
+################################################################################
+
+#SBATCH --job-name spu_out_col
+#SBATCH --time=02:00:00
+#$BATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+
+
+cd ~/salmon
+# supply the path to the directory contaiing subdirectories of salmon output
+# (this one is on the hogan lab folder on dartfs)
+Rscript quant_collect.R /dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq/salmon_out \
+pao1_asm676v1cdna_gene_names.csv \
+spu_metals_pao1_cdna_k15.csv
+#wait
+#cp *spu_metals_pao1_cdna_k15.csv /dartfs-hpc/rc/lab/H/HoganD/RNASeq_data/Sputum_Metals_RNAseq


### PR DESCRIPTION
In a folder, I've added scripts I used to process sputum rnaseq data for the metals spike-in experiment. 

- There is a short README on how the scripts were used.
- The salmon_metals_spu.script file was used for all sputum rnaseq samples (not just metals, as the name may imply). Inside it are all the salmon parameters. 
- Additionally, salmon_ti.script contains the parameters used for making the transcriptome index used.
- the yml files are for the conda environments in which the salmon programs were run.
